### PR TITLE
Simplify average spend - ordered ratio

### DIFF
--- a/src/main/java/com/combatzak/coffeerunner/model/Teammate.java
+++ b/src/main/java/com/combatzak/coffeerunner/model/Teammate.java
@@ -204,7 +204,10 @@ public class Teammate {
     }
 
     public double getSpendCostRatio() {
-        if (daysParticipated == 0 || totalDrinkCost == 0) return 0;
-        return getAverageDailySpend() / getAverageOrder();
+        if (this.totalDrinkCost == 0.0) {
+            return 1.0;
+        }
+
+        return this.totalPaid / this.totalDrinkCost;
     }
 }


### PR DESCRIPTION
Old method:
spendRatio = averageDailySpend / averageDrinkCost

averageDailySpend = totalSpend / daysParticipated
averageDrinkCost = totalCost / daysParticipated

thus

spendRatio = (totalSpend / daysParticipated) / (totalCost / daysParticipated)

and so

spendRatio = totalSpend / totalCost

This reduces the calculation's required floating point divs by 2